### PR TITLE
Halve default particle speeds and white background

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover"/>
   <title>Particle City — Roads & Buildings</title>
   <style>
-    html,body{margin:0;height:100%;background:#0a0c11;}
+    html,body{margin:0;height:100%;background:#fff;}
   </style>
 </head>
 <body>

--- a/sketch.js
+++ b/sketch.js
@@ -8,7 +8,7 @@ const q = new URLSearchParams(location.search);
 const HUE   = +q.get('hue')   || 40.57;     // 色相（HSL 0–360）
 const BDEN  = +q.get('bden')  || 1.0;       // 建物内部ターゲットの保持率スケール
 const RDEN  = +q.get('rden')  || 10.0;      // 道路粒子密度
-const FLOW  = +q.get('flow')  || 0.5;       // 道路粒子の基本速度
+const FLOW  = +q.get('flow')  || 0.25;      // 道路粒子の基本速度（デフォルトを半減）
 const FLOW_NOISE = +(q.get('fnoise') || 0.1);
 const TURB       = +(q.get('turb')   || 1.0);
 const GUST       = +(q.get('gust')   || 2.0);
@@ -49,7 +49,7 @@ const MPULSE   = +(q.get('mpulse')|| 1.2);
 const ERUN      = (q.get('erun')   ?? '1') !== '0';
 const E_RING    = +(q.get('ering')   || 2.0);
 const ER_STEP   = +(q.get('erstep')  || 12.0);
-const ER_SPEED  = +(q.get('erspeed') || 1.35);
+const ER_SPEED  = +(q.get('erspeed') || 0.675);
 const ER_JIT    = +(q.get('erjit')   || 0.9);
 const ER_SIZE   = +(q.get('ersize')  || 1.7);
 const ER_ALPHA  = +(q.get('eralpha') || 0.85);
@@ -172,8 +172,8 @@ function draw(){
   // 波紋
   if (RIPPLE) drawRipplesOn(rippleG);
 
-  // compose（黒背景）
-  background(0, 0, 5, 1);
+  // compose（白背景）
+  background(0, 0, 100, 1);
   image(trailG, 0, 0, width, height);
   if (RIPPLE) image(rippleG, 0, 0, width, height);
 

--- a/sketch_keep.js
+++ b/sketch_keep.js
@@ -12,7 +12,7 @@ const q = new URLSearchParams(location.search);
 const HUE   = +q.get('hue')   || 40.57;  // 色相（HSLの0–360°）
 const BDEN  = +q.get('bden')  || 0.1;    // 建物の粒子密度
 const RDEN  = +q.get('rden')  || 0.5;    // 道路の粒子密度
-const FLOW  = +q.get('flow')  || 0.5;    // 道路粒子の基本速度
+const FLOW  = +q.get('flow')  || 0.25;   // 道路粒子の基本速度（デフォルトを半減）
 const FLOW_NOISE = +(q.get('fnoise') || 0.1); // フローフィールド強さ
 const TURB       = +(q.get('turb')   || 1.0); // 乱流係数
 const GUST       = +(q.get('gust')   || 2.0); // マウス“ガスト”
@@ -86,7 +86,7 @@ function setup(){
   trailG.colorMode(HSL,360,100,100,1);
   trailG.noStroke();
   // trailG.background(220,18,7,1); // 初期化（ベース色）
-  trailG.background(0, 0, 5, 1); // 初期化（白）
+  trailG.background(0, 0, 100, 1); // 初期化（白）
 
   rippleG = createGraphics(width, height);
   rippleG.pixelDensity(pd);
@@ -183,7 +183,7 @@ function draw(){
 
   // 3) 合成
   // background(220, 18, 7, 1);
-  background(0, 0, 5, 1);
+  background(0, 0, 100, 1);
   image(trailG, 0, 0, width, height);
   if (RIPPLE) image(rippleG, 0, 0, width, height);
 }


### PR DESCRIPTION
## Summary
- Reduce default road particle speed from 0.5 to 0.25
- Reduce default edge runner speed from 1.35 to 0.675
- Update legacy script with halved road particle speed
- Switch page and canvas backgrounds to white

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b2edb2b883259519fa1a52e2ec4d